### PR TITLE
Comment out numpy warning filter

### DIFF
--- a/obsplanning.py
+++ b/obsplanning.py
@@ -74,7 +74,7 @@ from tqdm import tqdm
 # Some of the imported packages use this behavior, so is not possible to to this on the fly.  
 # I am opting here to suppress this particular warning type, to avoid these repeated warnings that do 
 # not currently impact the functionality of obsplanning.
-np.warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
+# np.warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
 
 
 ##############################################################################


### PR DESCRIPTION
The warning filter causes the library to throw an error on import - we should handle warnings inside the end-user script and not within the library (or at least provide the option to enable/disable.)

This is a quick workaround, but recommend updating the root cause to work within numpy in the future.